### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/django-tests.yaml
+++ b/.github/workflows/django-tests.yaml
@@ -1,4 +1,6 @@
 name: Django Tests
+permissions:
+  contents: read
 
 on:
   pull_request:


### PR DESCRIPTION
Potential fix for [https://github.com/Skill-Forge-Project/skill_forge_backend/security/code-scanning/1](https://github.com/Skill-Forge-Project/skill_forge_backend/security/code-scanning/1)

To fix this issue, explicitly set the `permissions` block to only the minimum required for the workflow to function. Since all steps only need to check out code and run tests, only `contents: read` is needed. The best place to add this is at the workflow root (top-level), directly underneath the workflow `name:` before `on:`. This ensures all jobs inherit the minimal token privileges. No changes outside this block are needed. No additional imports or code are required.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
